### PR TITLE
debugging merging rule

### DIFF
--- a/Snakemake/workflow/rules/merge_samples_vcf.smk
+++ b/Snakemake/workflow/rules/merge_samples_vcf.smk
@@ -57,13 +57,14 @@ if len(allFiles) != 1:
                 vcf=vcflist_input[i]
                 ovcf=vcflist_output[i]
                 samples=samplelist[i]
-                if i in set(track):
+                if (i in set(track)) and (len(samples) != 0):
                     shell('bcftools view -S {samples} --force-samples {vcf} -O z -o {ovcf} \
                             bcftoools index {ovcf}')
+                elif len(samples) == 0:
+                    shell('touch {ovcf}.ignore')
                 else
                     shell('bcftool view {vcf} -O z -o {ovcf} \
                             bcftools index {ovcf}')
-
             # for i, ofile in enumerate(output):
             #     with open(ofile, 'w') as f:
             #         [f.write(f'{line}\n') for line in samplelist[i]]

--- a/Snakemake/workflow/rules/prepare_files_for_tsinfer.smk
+++ b/Snakemake/workflow/rules/prepare_files_for_tsinfer.smk
@@ -96,7 +96,6 @@ rule match_ancestral_vcf:
                 grep -w "${line}" {input.major} >> {tmp}
             fi
         done
-        cut -d',' -f 2 tmp > {output}
         """
 
 rule change_infoAA_vcf:
@@ -111,7 +110,7 @@ rule change_infoAA_vcf:
         """
         HEADERNUM=$(( $(bcftools view -h {input.vcf} | wc -l) - 1 ))
         INFOLINE=$(( $(bcftools view -h {input.vcf} | grep -Fn "INFO" | head -1 | cut -d':' -f 1) ))
-        awk -v HEADER=$HEADERNUM -v INFO=$INFOLINE 'NR==FNR{{{{a[FNR] = $1; next}}}} FNR<=HEADER{{{{print}}}}; \
+        awk -OFS="," -v HEADER=$HEADERNUM -v INFO=$INFOLINE 'NR==FNR{{{{a[FNR] = $2; next}}}} FNR<=HEADER{{{{print}}}}; \
         FNR==INFO{{{{printf "##INFO=<ID=AA,Number=1,Type=String,Description=Ancestral Allele>\\n"}}}}; \
         FNR>HEADER{{{{$8="AA="a[FNR-HEADER]; print}}}}' OFS="\t" {input.ancestralAllele} {input.vcf} > {output}
         """


### PR DESCRIPTION
Add an extra check before filtering vcfs to avoid filtering with empty lists. 
If, after comparing it generates an empty list indicates that the file must be duplicated. 
Will check, and if that is the case, just output an empty file.ignore -- won't be used for merging.